### PR TITLE
test: enforce coverage threshold (PLAN-6.2, #25)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ignore = []
 
 # Pytest configuration
 [tool.pytest.ini_options]
-addopts = "-q --cov --cov-report=term-missing"
+addopts = "-q --cov=mcp_maven_central_search --cov-report=term-missing"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 pythonpath = ["."]
@@ -66,7 +66,7 @@ branch = true
 source = ["mcp_maven_central_search"]
 
 [tool.coverage.report]
-fail_under = 0
+fail_under = 80
 show_missing = true
 skip_covered = true
 


### PR DESCRIPTION
Implements PLAN-6.2 (Issue #25): Coverage enforcement ≥ 80% using pytest-cov.

Summary:
- Configure pytest to always collect coverage for `mcp_maven_central_search` and show a terminal summary.
- Enforce coverage threshold via coverage config (`fail_under = 80`).
- CI runs `uv run pytest` and will fail if coverage < 80%; logs include coverage summary.

Files changed:
- `pyproject.toml`: set `addopts` to `--cov=mcp_maven_central_search --cov-report=term-missing`, set `[tool.coverage.report].fail_under = 80`.
- `.github/workflows/ci.yml`: CI continues to run pytest; coverage enforcement is handled by config.

Local validation:
- Commands run:
  - `uv sync`
  - `uv run ruff format .`
  - `uv run ruff check .` → All checks passed
  - `uv run pyright` → 0 errors, 0 warnings
  - `uv run pytest` → 104 passed, coverage 90.21%

Coverage result:
- Total coverage: 90.21% (≥ 80%)

Notes:
- No production code changes.
- No new runtime dependencies; `pytest-cov` is already in dev dependency group.

Work-Item: PLAN-6.2
Refs: #25