### PR TITLE
test: add integration-style test harness (PLAN-6.1, #24)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+import respx
+
+from mcp_maven_central_search import server as server_module
+from mcp_maven_central_search.config import Settings
+
+
+@pytest.fixture(autouse=True)
+async def _reset_caches() -> AsyncIterator[None]:
+    # Ensure isolation across tests by clearing server-level caches
+    await server_module._versions_cache.clear()
+    await server_module._versions_list_cache.clear()
+    await server_module._declared_deps_cache.clear()
+    yield
+
+
+@pytest.fixture
+def respx_router() -> Iterator[respx.Router]:
+    with respx.mock(assert_all_called=False) as router:
+        yield router
+
+
+@pytest.fixture
+def respx_versions_mock(respx_router: respx.Router):
+    """Prepare a versions endpoint route on the Maven Central search URL.
+
+    Tests can call `.mock(return_value=...)` and inspect `.called`/`.call_count`.
+    """
+
+    base_url = Settings().MAVEN_CENTRAL_BASE_URL
+    return respx_router.get(base_url)
+
+
+@pytest.fixture
+def pom_url_builder() -> callable:
+    # Helper to construct the canonical POM URL used by download_pom
+    from mcp_maven_central_search.pom import _build_pom_url
+
+    def _f(group_id: str, artifact_id: str, version: str) -> str:
+        return _build_pom_url(group_id, artifact_id, version)
+
+    return _f

--- a/tests/integration/test_get_declared_dependencies_integration.py
+++ b/tests/integration/test_get_declared_dependencies_integration.py
@@ -1,0 +1,90 @@
+import httpx
+import pytest
+
+from mcp_maven_central_search.server import get_declared_dependencies_core
+
+POM_XML = """
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.acme</groupId>
+  <artifactId>demo</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.foo</groupId>
+      <artifactId>core</artifactId>
+      <version>1.2.3</version>
+      <!-- no scope -> treated as compile -->
+    </dependency>
+    <dependency>
+      <groupId>org.foo</groupId>
+      <artifactId>optional-lib</artifactId>
+      <version>2.0.0</version>
+      <optional>true</optional>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bar</groupId>
+      <artifactId>testkit</artifactId>
+      <version>0.9.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.bom</groupId>
+        <artifactId>managed</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <properties>
+    <prop.version>3.4.5</prop.version>
+  </properties>
+</project>
+"""
+
+
+@pytest.mark.asyncio
+async def test_declared_dependencies_extraction_and_filters(respx_router, pom_url_builder):
+    group = "com.acme"
+    artifact = "demo"
+    version = "1.0.0"
+    url = pom_url_builder(group, artifact, version)
+
+    respx_router.get(url).mock(return_value=httpx.Response(200, content=POM_XML.encode("utf-8")))
+
+    # Default: include_optional=True, include_scopes=None -> all deps included
+    resp_all = await get_declared_dependencies_core(
+        group_id=group, artifact_id=artifact, version=version
+    )
+
+    names_all = [
+        (d.group_id, d.artifact_id, d.scope or None, d.optional) for d in resp_all.dependencies
+    ]
+    assert ("org.foo", "core", None, False) in names_all  # missing scope preserved as None
+    assert ("org.foo", "optional-lib", "runtime", True) in names_all
+    assert ("org.bar", "testkit", "test", False) in names_all
+
+    # Exclude optional dependencies
+    resp_no_opt = await get_declared_dependencies_core(
+        group_id=group, artifact_id=artifact, version=version, include_optional=False
+    )
+    names_no_opt = {(d.group_id, d.artifact_id) for d in resp_no_opt.dependencies}
+    assert ("org.foo", "optional-lib") not in names_no_opt
+
+    # Scope filtering: treat missing scope as 'compile'. Include only compile
+    resp_compile_only = await get_declared_dependencies_core(
+        group_id=group,
+        artifact_id=artifact,
+        version=version,
+        include_scopes=["compile"],
+    )
+    scopes = {
+        (d.group_id, d.artifact_id, (d.scope or "compile")) for d in resp_compile_only.dependencies
+    }
+    # core has missing scope -> treated as compile and should be included
+    assert ("org.foo", "core", "compile") in scopes
+    # runtime/test should be excluded
+    assert not any(ga for ga in scopes if ga[1] in {"optional-lib", "testkit"})

--- a/tests/integration/test_get_latest_version_integration.py
+++ b/tests/integration/test_get_latest_version_integration.py
@@ -1,0 +1,44 @@
+import httpx
+import pytest
+
+from mcp_maven_central_search.server import get_latest_version_core
+
+
+@pytest.mark.asyncio
+async def test_get_latest_version_filters_prereleases_and_uses_cache(respx_versions_mock):
+    # Arrange: mock Maven Central versions response with mixed stable/prerelease
+    group = "com.acme"
+    artifact = "demo"
+
+    # First call returns data; any further calls should not be made due to cache/dedup
+    response_json = {
+        "response": {
+            "docs": [
+                {"v": "1.0.0"},
+                {"v": "1.1.0"},
+                {"v": "2.0.0-alpha"},
+                {"v": "2.0.0"},
+                {"v": "2.1.0-beta.1"},
+                {"v": "2.1.0"},
+            ]
+        }
+    }
+
+    route = respx_versions_mock.mock(return_value=httpx.Response(200, json=response_json))
+
+    # Act: first call should hit HTTP
+    result1 = await get_latest_version_core(group_id=group, artifact_id=artifact)
+    # Second call with same params should be served from cache (no new HTTP)
+    result2 = await get_latest_version_core(group_id=group, artifact_id=artifact)
+
+    # Assert: prereleases excluded; highest stable is 2.1.0
+    assert result1.latest is not None
+    assert result1.latest.version == "2.1.0"
+    assert result1.stable_filter_applied is True
+
+    # Cache should return identical payload
+    assert result2.model_dump() == result1.model_dump()
+
+    # Only a single underlying HTTP request was made
+    assert route.called
+    assert route.call_count == 1

--- a/tests/integration/test_get_versions_integration.py
+++ b/tests/integration/test_get_versions_integration.py
@@ -1,0 +1,67 @@
+import httpx
+import pytest
+
+from mcp_maven_central_search.server import get_versions_core
+
+
+@pytest.mark.asyncio
+async def test_get_versions_default_stable_only_descending(respx_versions_mock):
+    group = "com.acme"
+    artifact = "demo"
+
+    response_json = {
+        "response": {
+            "docs": [
+                {"v": "1.0.0"},
+                {"v": "1.1.0"},
+                {"v": "2.0.0-alpha"},
+                {"v": "2.0.0"},
+                {"v": "2.1.0-beta.1"},
+                {"v": "2.1.0"},
+            ]
+        }
+    }
+
+    respx_versions_mock.mock(return_value=httpx.Response(200, json=response_json))
+
+    result = await get_versions_core(group_id=group, artifact_id=artifact)
+
+    # Should exclude prereleases and be ordered highest -> lowest
+    versions = [v.version for v in result.versions]
+    assert versions == ["2.1.0", "2.0.0", "1.1.0", "1.0.0"]
+    assert result.stable_filter_applied is True
+
+
+@pytest.mark.asyncio
+async def test_get_versions_include_prereleases(respx_versions_mock):
+    group = "com.acme"
+    artifact = "demo"
+
+    response_json = {
+        "response": {
+            "docs": [
+                {"v": "1.0.0"},
+                {"v": "1.1.0"},
+                {"v": "2.0.0-alpha"},
+                {"v": "2.0.0"},
+                {"v": "2.1.0-beta.1"},
+                {"v": "2.1.0"},
+            ]
+        }
+    }
+
+    respx_versions_mock.mock(return_value=httpx.Response(200, json=response_json))
+
+    result = await get_versions_core(group_id=group, artifact_id=artifact, include_prereleases=True)
+
+    # With prereleases: include all, ordered highest -> lowest
+    versions = [v.version for v in result.versions]
+    assert versions == [
+        "2.1.0",
+        "2.1.0-beta.1",
+        "2.0.0",
+        "2.0.0-alpha",
+        "1.1.0",
+        "1.0.0",
+    ]
+    assert result.stable_filter_applied is False


### PR DESCRIPTION
Implements PLAN-6.1 (Issue #24): add integration-style test harness that exercises core MCP flows with mocked HTTP calls.

Scope and highlights:
- New integration tests under tests/integration/:
  - test_get_latest_version_integration.py — verifies prerelease filtering, correct ordering, and cache/dedup via single HTTP call
  - test_get_versions_integration.py — validates stable-only default, include_prereleases=True behavior, and descending order
  - test_get_declared_dependencies_integration.py — checks POM download + parsing, optional filtering, scope filtering (missing scope treated as compile)
- Shared fixtures in tests/conftest.py:
  - respx-based HTTP stubs for Maven Central search and POM fetch
  - automatic cache reset between tests to ensure isolation

Quality gates executed locally:
- uv run ruff format .
- uv run ruff check . (clean)
- uv run pyright (clean)
- uv run pytest (all tests pass; coverage ~90%)

Notes:
- Tests are deterministic and do not access the network (respx mocks).
- No production code changes were required.

Work-Item: PLAN-6.1
Refs: #24