### PR TITLE
feat: update search endpoint

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -108,10 +108,10 @@ Configuration is implemented using **pydantic-settings** and is fully overridabl
 
 * `MAVEN_CENTRAL_BASE_URL`
 
-    * Default: `https://search.maven.org/solrsearch/select`
+    * Default: `https://central.sonatype.com/solrsearch/select`
 * `MAVEN_CENTRAL_REMOTE_CONTENT_BASE_URL`
 
-    * Default: `https://search.maven.org/remotecontent`
+    * Default: `https://central.sonatype.com/remotecontent`
 * `HTTP_TIMEOUT_SECONDS`
 
     * Default: 10

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Common settings:
 
 ### Maven Central endpoints
 
-- `MAVEN_CENTRAL_BASE_URL` (default: `https://search.maven.org/solrsearch/select`)
-- `MAVEN_CENTRAL_REMOTE_CONTENT_BASE_URL` (default: `https://search.maven.org/remotecontent`)
+- `MAVEN_CENTRAL_BASE_URL` (default: `https://central.sonatype.com/solrsearch/select`)
+- `MAVEN_CENTRAL_REMOTE_CONTENT_BASE_URL` (default: `https://central.sonatype.com/remotecontent`)
 
 ### HTTP behavior
 

--- a/mcp_maven_central_search/central_api.py
+++ b/mcp_maven_central_search/central_api.py
@@ -49,13 +49,13 @@ def build_ga_query(group_id: str, artifact_id: str) -> str:
     """Build the Solr `q` for group/artifact coordinate search.
 
     Example:
-        q = g:"com.example" AND a:"my-artifact"
+        q = g:com.example AND a:my-artifact
     """
     g = _validate_non_empty("group_id", group_id, _MAX_COORD_LEN)
     a = _validate_non_empty("artifact_id", artifact_id, _MAX_COORD_LEN)
     g_esc = _escape_for_solr_literal(g)
     a_esc = _escape_for_solr_literal(a)
-    return f'g:"{g_esc}" AND a:"{a_esc}"'
+    return f"g:{g_esc} AND a:{a_esc}"
 
 
 def build_params_for_versions(group_id: str, artifact_id: str, rows: int) -> dict[str, str | int]:
@@ -63,7 +63,7 @@ def build_params_for_versions(group_id: str, artifact_id: str, rows: int) -> dic
 
     Required keys:
       - core = gav
-      - q = g:"..." AND a:"..."
+      - q = g:... AND a:...
       - rows = <limit>
       - sort = v desc
       - wt = json

--- a/mcp_maven_central_search/central_api.py
+++ b/mcp_maven_central_search/central_api.py
@@ -65,6 +65,7 @@ def build_params_for_versions(group_id: str, artifact_id: str, rows: int) -> dic
       - core = gav
       - q = g:"..." AND a:"..."
       - rows = <limit>
+      - sort = v desc
       - wt = json
     """
     if not isinstance(rows, int) or rows <= 0:
@@ -74,6 +75,7 @@ def build_params_for_versions(group_id: str, artifact_id: str, rows: int) -> dic
         "q": build_ga_query(group_id, artifact_id),
         "rows": rows,
         "wt": "json",
+        "sort": "v desc",
     }
     return params
 
@@ -89,7 +91,7 @@ def build_params_for_search(query: str, rows: int) -> dict[str, str | int]:
     q = _validate_non_empty("query", query, _MAX_QUERY_LEN)
     if not isinstance(rows, int) or rows <= 0:
         raise ValueError("rows must be a positive integer")
-    return {"q": q, "rows": rows, "wt": "json"}
+    return {"q": q, "rows": rows, "wt": "json", "sort": "v desc"}
 
 
 _logger = logging.getLogger(__name__)

--- a/mcp_maven_central_search/config.py
+++ b/mcp_maven_central_search/config.py
@@ -25,8 +25,8 @@ class Settings(BaseSettings):
     """
 
     # Maven Central endpoints
-    MAVEN_CENTRAL_BASE_URL: str = "https://search.maven.org/solrsearch/select"
-    MAVEN_CENTRAL_REMOTE_CONTENT_BASE_URL: str = "https://search.maven.org/remotecontent"
+    MAVEN_CENTRAL_BASE_URL: str = "https://central.sonatype.com/solrsearch/select"
+    MAVEN_CENTRAL_REMOTE_CONTENT_BASE_URL: str = "https://central.sonatype.com/remotecontent"
 
     # HTTP behavior
     HTTP_TIMEOUT_SECONDS: int = Field(default=10, ge=1)

--- a/tests/unit/test_central_api_query_builder.py
+++ b/tests/unit/test_central_api_query_builder.py
@@ -9,13 +9,13 @@ from mcp_maven_central_search.central_api import (
 
 def test_build_ga_query_basic():
     q = build_ga_query("org.apache.commons", "commons-lang3")
-    assert q == 'g:"org.apache.commons" AND a:"commons-lang3"'
+    assert q == "g:org.apache.commons AND a:commons-lang3"
 
 
 def test_build_ga_query_escaping_quotes_and_backslashes():
     q = build_ga_query('com.example"weird', r"art\ifact")
     # Expect embedded quote and backslash to be escaped inside the quoted literal
-    assert q == 'g:"com.example\\"weird" AND a:"art\\\\ifact"'
+    assert q == 'g:com.example\\"weird AND a:art\\\\ifact'
 
 
 def test_build_params_for_versions_contains_required_keys():
@@ -23,7 +23,7 @@ def test_build_params_for_versions_contains_required_keys():
     assert params["core"] == "gav"
     assert params["wt"] == "json"
     assert params["rows"] == 25
-    assert params["q"] == 'g:"g" AND a:"a"'
+    assert params["q"] == "g:g AND a:a"
     assert params["sort"] == "v desc"
 
 

--- a/tests/unit/test_central_api_query_builder.py
+++ b/tests/unit/test_central_api_query_builder.py
@@ -24,11 +24,12 @@ def test_build_params_for_versions_contains_required_keys():
     assert params["wt"] == "json"
     assert params["rows"] == 25
     assert params["q"] == 'g:"g" AND a:"a"'
+    assert params["sort"] == "v desc"
 
 
 def test_build_params_for_search_contains_required_keys():
     params = build_params_for_search("kotlin coroutine", 10)
-    assert params == {"q": "kotlin coroutine", "rows": 10, "wt": "json"}
+    assert params == {"q": "kotlin coroutine", "rows": 10, "wt": "json", "sort": "v desc"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,7 +5,7 @@ from mcp_maven_central_search.config import Settings
 
 def test_defaults_representative_fields():
     s = Settings()
-    assert s.MAVEN_CENTRAL_BASE_URL == "https://search.maven.org/solrsearch/select"
+    assert s.MAVEN_CENTRAL_BASE_URL == "https://central.sonatype.com/solrsearch/select"
     assert s.HTTP_TIMEOUT_SECONDS == 10
     assert s.CACHE_ENABLED is True
     assert s.LOG_LEVEL == "INFO"
@@ -37,6 +37,6 @@ def test_env_isolation(monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv(key, raising=False)
 
     s = Settings()
-    assert s.MAVEN_CENTRAL_BASE_URL == "https://search.maven.org/solrsearch/select"
+    assert s.MAVEN_CENTRAL_BASE_URL == "https://central.sonatype.com/solrsearch/select"
     assert s.HTTP_TIMEOUT_SECONDS == 10
     assert s.CACHE_ENABLED is True

--- a/tests/unit/test_tool_get_latest_version.py
+++ b/tests/unit/test_tool_get_latest_version.py
@@ -18,7 +18,7 @@ def _mk_response(versions: list[str]) -> dict[str, Any]:
 async def test_latest_version_stable_default_picks_correct() -> None:
     # mix of stable and pre-release; stable default should pick highest stable
     with respx.mock(assert_all_called=True) as router:
-        route = router.get("https://search.maven.org/solrsearch/select").mock(
+        route = router.get("https://central.sonatype.com/solrsearch/select").mock(
             return_value=httpx.Response(
                 200,
                 json=_mk_response(
@@ -47,7 +47,7 @@ async def test_latest_version_stable_default_picks_correct() -> None:
 @pytest.mark.asyncio
 async def test_include_prereleases_can_select_prerelease_when_highest() -> None:
     with respx.mock(assert_all_called=True) as router:
-        router.get("https://search.maven.org/solrsearch/select").mock(
+        router.get("https://central.sonatype.com/solrsearch/select").mock(
             return_value=httpx.Response(
                 200,
                 json=_mk_response(
@@ -74,7 +74,7 @@ async def test_include_prereleases_can_select_prerelease_when_highest() -> None:
 @pytest.mark.asyncio
 async def test_no_results_returns_tool_error() -> None:
     with respx.mock(assert_all_called=True) as router:
-        router.get("https://search.maven.org/solrsearch/select").mock(
+        router.get("https://central.sonatype.com/solrsearch/select").mock(
             return_value=httpx.Response(200, json=_mk_response([]))
         )
 
@@ -96,7 +96,9 @@ async def test_caching_and_inflight_dedupe_reduce_calls() -> None:
         return httpx.Response(200, json=_mk_response(["0.9.0", "1.0.0", "1.0.1"]))
 
     with respx.mock(assert_all_called=True) as router:
-        route = router.get("https://search.maven.org/solrsearch/select").mock(side_effect=handler)
+        route = router.get("https://central.sonatype.com/solrsearch/select").mock(
+            side_effect=handler
+        )
 
         # Fire multiple concurrent identical requests
         tasks = [


### PR DESCRIPTION
# Summary

The original URL used for the Maven Central search was actually deprecated by Sonatype; this PR updates the default URL to the new (or actually, interim, according to support) endpoint for the service.

## References

No issues were created for this, nor additions to the `PLANNING` document made.

## Testing

* [ ] `uv run pytest`
* [ ] `uv run ruff check .`
* [ ] `uv run pyright`

## Checklist

* [ ] Scope limited to the referenced issue
* [ ] Follows `PLANNING.md`
* [ ] CI is expected to pass
